### PR TITLE
fixed creating temp directories for sync

### DIFF
--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -1,0 +1,10 @@
+import { existsSync, mkdtempSync } from 'fs';
+import { sync as mkdirp } from 'mkdirp';
+import { join } from 'path';
+
+export function makeTempDirectory(base: string, prefix: string = 'tmp-') {
+	if (!existsSync(base)) {
+		mkdirp(base);
+	}
+	return mkdtempSync(join(base, prefix));
+}

--- a/tasks/api.ts
+++ b/tasks/api.ts
@@ -13,9 +13,9 @@ import getReleases, {
 	ReleaseFilter
 } from '../src/commands/getReleases';
 import { join, resolve } from 'path';
-import { mkdtempSync } from 'fs';
 import installDependencies from '../src/commands/installDependencies';
 import { logger } from '../src/log';
+import { makeTempDirectory } from '../src/util/file';
 
 interface BaseOptions {
 	dest: string;
@@ -80,10 +80,6 @@ function getFilterOptions(filter?: RemoteApiOptions['filter']): ReleaseFilter[] 
 	return [ filter ];
 }
 
-function createTempDirectory(name: string = ''): string {
-	return mkdtempSync(join('.sync', name));
-}
-
 export = function (grunt: IGrunt) {
 	async function typedocTask(this: IMultiTask<any>) {
 		const options: any = this.options<Partial<TaskOptions>>({
@@ -101,7 +97,8 @@ export = function (grunt: IGrunt) {
 
 		if (isRemoteOptions(options)) {
 			const repo = getGitHub(options.repo);
-			const cloneDirectory = options.cloneDirectory ? options.cloneDirectory : createTempDirectory(repo.name);
+			const cloneDirectory = options.cloneDirectory ?
+				options.cloneDirectory : makeTempDirectory(join('.sync', repo.name));
 			const missing = await getMissing(repo, options);
 			const pathTemplate = format === 'json' ? getJsonApiPath : getHtmlApiPath;
 

--- a/tests/integration/all.ts
+++ b/tests/integration/all.ts
@@ -1,2 +1,3 @@
+import './file';
 import './git';
 import './typedoc';

--- a/tests/integration/file.ts
+++ b/tests/integration/file.ts
@@ -1,0 +1,14 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { makeTempDirectory } from 'src/util/file';
+import { existsSync, statSync } from 'fs';
+
+registerSuite({
+	name: 'file',
+
+	tempDirectory() {
+		const path = makeTempDirectory('./test');
+		assert.isTrue(existsSync(path));
+		assert.isTrue(statSync(path).isDirectory());
+	}
+});

--- a/tests/integration/git.ts
+++ b/tests/integration/git.ts
@@ -4,7 +4,7 @@ import Git from 'src/util/Git';
 import { tmpDirectory } from '../_support/tmpFiles';
 
 registerSuite({
-	name: 'typedoc',
+	name: 'git',
 
 	async build() {
 		const out = tmpDirectory();


### PR DESCRIPTION
Sync fails if the base directory where the temp directory is made does not exist