### PR TITLE
add `_support/tasks` helper methods file for testing tasks

### DIFF
--- a/tests/_support/tasks.ts
+++ b/tests/_support/tasks.ts
@@ -1,0 +1,8 @@
+import { SinonStub } from 'sinon';
+import { Deferred } from 'intern/lib/Test';
+
+export function setupWrappedAsyncStub(stub: SinonStub, dfd: Deferred<any>, callback: () => any) {
+	stub.callsFake((task: () => Promise<any>) => {
+		task().then(dfd.callback(callback));
+	});
+}

--- a/tests/_support/tasks.ts
+++ b/tests/_support/tasks.ts
@@ -1,8 +1,8 @@
 import { SinonStub } from 'sinon';
 import { Deferred } from 'intern/lib/Test';
 
-export function setupWrappedAsyncStub(stub: SinonStub, dfd: Deferred<any>, callback: () => any) {
+export function setupWrappedAsyncStub(this: any, stub: SinonStub, dfd: Deferred<any>, callback: () => any) {
 	stub.callsFake((task: () => Promise<any>) => {
-		task().then(dfd.callback(callback));
+		task.call(this).then(dfd.callback(callback));
 	});
 }


### PR DESCRIPTION
This PR may have additional commits before I'm finished with task testing, but should be merged into
master before any of the `tasks` tests.