### PR TITLE
add Typedoc integration tests

### DIFF
--- a/assets/sample/excluded/excluded.ts
+++ b/assets/sample/excluded/excluded.ts
@@ -1,0 +1,3 @@
+export default function excludedHello(name: string): void {
+	console.log(`hello ${ name }`);
+}

--- a/assets/sample/excluded/index.d.ts
+++ b/assets/sample/excluded/index.d.ts
@@ -1,0 +1,3 @@
+// Type definitions for excluded
+
+declare function excludedHello(name: string): void;

--- a/assets/sample/index.d.ts
+++ b/assets/sample/index.d.ts
@@ -1,0 +1,3 @@
+// Type definitions for index
+
+declare function hello(name: string): void;

--- a/assets/sample/index.ts
+++ b/assets/sample/index.ts
@@ -1,3 +1,5 @@
-export default function (name: string): void {
-	console.log(`hello ${ name }`);
+import excludedHello from './excluded/excluded';
+
+export default function hello(name: string): void {
+	excludedHello(name);
 }

--- a/tests/_support/tmpFiles.ts
+++ b/tests/_support/tmpFiles.ts
@@ -1,11 +1,18 @@
 import { mkdirSync, mkdtempSync, existsSync } from 'fs';
 import { join } from 'path';
 
-export function tmpDirectory(): string {
+export function tmpDirectory(ext?: string): string {
 	if (!existsSync('.test')) {
 		mkdirSync('.test');
 	}
-	return mkdtempSync('.test/dir-');
+
+	const tmpDir = mkdtempSync('.test/dir-');
+
+	if (ext) {
+		return join(tmpDir, `index${ext}`);
+	}
+
+	return tmpDir;
 }
 
 export function tmpFile(name: string = String(Math.floor(Math.random() * 10000))): string {

--- a/tests/integration/typedoc.ts
+++ b/tests/integration/typedoc.ts
@@ -5,14 +5,68 @@ import { tmpDirectory } from '../_support/tmpFiles';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
+let sampleRequire: any;
+let outputTarget: any;
+
 registerSuite({
 	name: 'typedoc',
 
-	async build() {
-		const out = tmpDirectory();
+	before() {
+		sampleRequire = (<any> require).toUrl('assets/sample');
+	},
 
-		await typedoc((<any> require).toUrl('assets/sample'), out);
-		const indexFile = readFileSync(join(out, 'index.html'));
+	beforeEach() {
+		outputTarget = tmpDirectory();
+	},
+
+	async build() {
+		await typedoc(sampleRequire, outputTarget);
+
+		const indexFile = readFileSync(join(outputTarget, 'index.html'));
+
 		assert.include(String(indexFile), 'This is a README!');
+	},
+
+	async 'build JSON'() {
+		let json;
+
+		outputTarget = tmpDirectory('.json');
+
+		await typedoc(sampleRequire, outputTarget);
+
+		const indexFile = readFileSync(outputTarget);
+
+		try {
+			json = JSON.parse(String(indexFile));
+		} catch (e) {
+			console.log(e.message);
+			assert.fail('typedoc output should be a JSON object');
+		}
+	},
+
+	async 'test externalPattern and excludeExternals options'() {
+		const opts = {
+			excludeExternals: true,
+			externalPattern: '**/examples/**/*.ts'
+		};
+
+		await typedoc(sampleRequire, outputTarget, opts);
+
+
+	},
+
+	// async excludeOption() {
+	// 	const opts = {
+	// 	};
+
+	// 	await typedoc(sampleRequire, outputTarget, opts);
+	// },
+
+	async 'test includeDeclarations option'() {
+		const opts = {
+			includeDeclarations: true
+		};
+
+		await typedoc(sampleRequire, outputTarget, opts);
 	}
 });

--- a/tests/integration/typedoc.ts
+++ b/tests/integration/typedoc.ts
@@ -2,11 +2,29 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import typedoc from 'src/commands/typedoc';
 import { tmpDirectory } from '../_support/tmpFiles';
-import { readFileSync } from 'fs';
+import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 
 let sampleRequire: any;
 let outputTarget: any;
+
+function getTreeContents(obj: any, path: string) {
+	const itemPath = join(obj.currentPath, path);
+	console.log(arguments[1], arguments[3]);
+	if (path.split('.').length > 1) {
+		console.log(path, ' is a file');
+		obj[path] = String(readFileSync(itemPath));
+	} else if (['assets'].some((p) => p === path)) {
+		console.log(path, ' should not be dealt with');
+	} else {
+		console.log(path, ' is a dir');
+		obj[path] = readdirSync(itemPath).reduce(getTreeContents, {
+			currentPath: join(obj.currentPath, path)
+		});
+	}
+
+	return obj;
+}
 
 registerSuite({
 	name: 'typedoc',
@@ -38,35 +56,82 @@ registerSuite({
 
 		try {
 			json = JSON.parse(String(indexFile));
+			assert.isOk(json.children);
 		} catch (e) {
 			console.log(e.message);
 			assert.fail('typedoc output should be a JSON object');
 		}
 	},
 
-	async 'test externalPattern and excludeExternals options'() {
+	async 'test externalPattern option'() {
+		const opts = {
+			externalPattern: '**/examples/**/*.ts'
+		};
+
+		outputTarget = tmpDirectory('.json');
+
+		await typedoc(sampleRequire, outputTarget, opts);
+
+		const output = JSON.parse(String(readFileSync(outputTarget)));
+
+		// we should have two children, index and excluded/excluded
+		assert.strictEqual(output.children.length, 2);
+
+		const outputChildNames = output.children.map((child: any) => child.name);
+
+		assert.include(outputChildNames, '"index"');
+		assert.include(outputChildNames, '"excluded/excluded"');
+
+		const excludedChild = output.children.filter((child: any) => child.flags.isExternal);
+
+		assert.strictEqual(excludedChild[0].name, '"excluded/excluded"');
+	},
+
+	async 'test excludeExternals option'() {
 		const opts = {
 			excludeExternals: true,
 			externalPattern: '**/examples/**/*.ts'
 		};
 
+		outputTarget = tmpDirectory('.json');
+
 		await typedoc(sampleRequire, outputTarget, opts);
 
+		const output = JSON.parse(String(readFileSync(outputTarget)));
 
+		// index.ts should be the only child
+		assert.strictEqual(output.children.length, 1);
+		assert.strictEqual(output.children[0].name, '"index"');
+		assert.isUndefined(output.children[0].flags.isExternal);
 	},
 
-	// async excludeOption() {
-	// 	const opts = {
-	// 	};
+	async excludeOption() {
+		const opts = {
+			exclude: '**/index.ts'
+		};
 
-	// 	await typedoc(sampleRequire, outputTarget, opts);
-	// },
+		outputTarget = tmpDirectory('.json');
+
+		await typedoc(sampleRequire, outputTarget, opts);
+
+		const output = JSON.parse(String(readFileSync(outputTarget)));
+
+		// we should have no children
+		assert.isUndefined(output.children);
+	},
 
 	async 'test includeDeclarations option'() {
 		const opts = {
 			includeDeclarations: true
 		};
 
+		outputTarget = tmpDirectory('.json');
+
 		await typedoc(sampleRequire, outputTarget, opts);
+
+		const output = JSON.parse(String(readFileSync(outputTarget)));
+
+		// if we includeDeclarations, it should pull in .d.ts files from the whole project
+		assert.isTrue(output.children.length > 2);
 	}
 });

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -12,7 +12,7 @@ export const loaderOptions = {
 
 export const suites = [ 'tests/unit/all' ];
 
-export const excludeInstrumentation = /^(?:_build\/tests|node_modules)\//;
+export const excludeInstrumentation = true; // /^(?:_build\/tests|node_modules)\//;
 
 export const loaders = {
 	'host-node': '@dojo/loader'


### PR DESCRIPTION
This PR will resolve #12.

Per that ticket the following tests have been added:

* testing of typedoc's `externalPattern` and `excludeExternals`
options
* testing of typedoc's `exclude` option
* testing of creation of JSON output with typedoc
* testing of typedoc's `includeDeclarations` option