### PR TITLE
Execute in the working directory if the repo doesn't exist

### DIFF
--- a/src/util/Git.ts
+++ b/src/util/Git.ts
@@ -40,7 +40,7 @@ export default class Git {
 		return promiseExec(`git checkout ${ version }`, { silent: false, cwd: this.cloneDirectory});
 	}
 
-	async clone(url: string)  {
+	async clone(url: string) {
 		if (!this.cloneDirectory) {
 			throw new Error('A clone directory must be set');
 		}

--- a/src/util/Git.ts
+++ b/src/util/Git.ts
@@ -25,7 +25,7 @@ export default class Git {
 	/**
 	 * Ensures that a repository is initialized and matches the provided url
 	 */
-	async assert(url: string) {
+	async assert(url: string): Promise<void> {
 		if (!this.isInitialized()) {
 			throw new Error(`Repository is not initialized at "${ this.cloneDirectory }"`);
 		}
@@ -40,7 +40,7 @@ export default class Git {
 		return promiseExec(`git checkout ${ version }`, { silent: false, cwd: this.cloneDirectory});
 	}
 
-	async clone(url: string) {
+	async clone(url: string)  {
 		if (!this.cloneDirectory) {
 			throw new Error('A clone directory must be set');
 		}
@@ -120,7 +120,7 @@ export default class Git {
 		return existsSync(this.keyFile);
 	}
 
-	async headRevision() {
+	async headRevision(): Promise<string> {
 		const proc = await exec(`git rev-parse HEAD`, { silent: false, cwd: this.cloneDirectory });
 		return (await toString(proc.stdout)).trim();
 	}

--- a/src/util/Git.ts
+++ b/src/util/Git.ts
@@ -97,7 +97,8 @@ export default class Git {
 	}
 
 	async getConfig(key: string): Promise<string> {
-		const proc = await exec(`git config ${ key }`, { silent: true, cwd: this.cloneDirectory });
+		const cwd = existsSync(this.cloneDirectory) ? this.cloneDirectory : process.cwd();
+		const proc = await exec(`git config ${ key }`, { silent: true, cwd });
 		return (await toString(proc.stdout)).trim();
 	}
 

--- a/tests/unit/src/util/Git.ts
+++ b/tests/unit/src/util/Git.ts
@@ -230,6 +230,7 @@ registerSuite({
 	},
 
 	async getConfig() {
+		existsSyncStub.withArgs(git.cloneDirectory).returns(true);
 		execStub.withArgs('git config key', {
 			silent: true,
 			cwd: git.cloneDirectory
@@ -237,6 +238,26 @@ registerSuite({
 		toStringStub.withArgs('key').returns('key');
 
 		const keyConfig = await git.getConfig('key');
+
+		assert.isTrue(execStub.calledOnce);
+		assert.isTrue(toStringStub.calledOnce);
+		assert.strictEqual(keyConfig, 'key');
+	},
+
+	async getConfigDirectoryDoesNotExist() {
+		const cwd = process.cwd();
+		const cloneDirectory = git.cloneDirectory;
+
+		existsSyncStub.withArgs(cwd).returns(false);
+		execStub.withArgs('git config key', {
+			silent: true,
+			cwd
+		}).returns({ stdout: 'key' });
+		toStringStub.withArgs('key').returns('key');
+
+		git.cloneDirectory = '_does_not_exist_';
+		const keyConfig = await git.getConfig('key');
+		git.cloneDirectory = cloneDirectory;
 
 		assert.isTrue(execStub.calledOnce);
 		assert.isTrue(toStringStub.calledOnce);

--- a/tests/unit/src/util/Travis.ts
+++ b/tests/unit/src/util/Travis.ts
@@ -14,7 +14,7 @@ registerSuite({
 	name: 'util/Travis',
 
 	before() {
-		requestStub = stub();
+		requestStub = stub() as SinonStub & Partial<{ get: SinonStub, post: SinonStub }>;
 		requestStub.post = stub();
 		requestStub.get = stub();
 	},


### PR DESCRIPTION

The `getConfig` function was being run before the directory it was trying to run in existed. This adds a fallback that uses the current working directory instead.



Resolves #22 