### PR TITLE
Escape JSON that is set as an environment variable

### DIFF
--- a/src/commands/initialize/initAuthorization.ts
+++ b/src/commands/initialize/initAuthorization.ts
@@ -47,10 +47,10 @@ export default async function initAuthorization(repo: GitHub, travis: Travis = n
 				fingerprint: repo.toString()
 			});
 
-			const tokenStr = JSON.stringify({
+			const tokenStr = `'${JSON.stringify({
 				type: 'oauth',
 				token: appAuth.token
-			});
+			})}'`;
 			await travisRepo.setEnvironmentVariables({ name: env.githubAuthName, value: tokenStr, isPublic: false });
 		}
 	}


### PR DESCRIPTION
Without this the build calls 
`export GITHUB_AUTH={"type":"oauth","token":"..."}`
which does not set the right value.